### PR TITLE
Gateway Port Fix

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -3,6 +3,6 @@ WORKDIR /app
 
 COPY target/analytics-service.jar .
 
-EXPOSE 8084
+EXPOSE 8080
 
 CMD [ "java", "-jar", "analytics-service.jar" ]

--- a/src/main/java/com/revature/autosurvey/analytics/controllers/ReportController.java
+++ b/src/main/java/com/revature/autosurvey/analytics/controllers/ReportController.java
@@ -13,7 +13,7 @@ import reactor.core.publisher.Mono;
 
 
 @RestController
-@RequestMapping(value = "/reports")
+@RequestMapping()
 public class ReportController {
 
 	@Autowired

--- a/src/main/java/com/revature/autosurvey/analytics/controllers/ReportController.java
+++ b/src/main/java/com/revature/autosurvey/analytics/controllers/ReportController.java
@@ -3,7 +3,6 @@ package com.revature.autosurvey.analytics.controllers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.revature.autosurvey.analytics.beans.Report;

--- a/src/main/java/com/revature/autosurvey/analytics/controllers/ReportController.java
+++ b/src/main/java/com/revature/autosurvey/analytics/controllers/ReportController.java
@@ -13,7 +13,6 @@ import reactor.core.publisher.Mono;
 
 
 @RestController
-@RequestMapping()
 public class ReportController {
 
 	@Autowired

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,8 +3,8 @@ logging.level.com.netflix.discovery=OFF
 logging.level.org.springframework.web=OFF
 
 spring.application.name=analytic-service
-server.port=8084
-eureka.client.service-url.defaultZone=http://localhost:8761/eureka
+server.port=0
+eureka.client.service-url.defaultZone=${EUREKA_URL:http://localhost:8761/eureka}
 # if we don't say anything in 2 seconds, there is something wrong with me
 eureka.instance.lease-expiration-duration-in-seconds=2
 # heartbeat every second

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,7 +3,7 @@ logging.level.com.netflix.discovery=OFF
 logging.level.org.springframework.web=OFF
 
 spring.application.name=analytic-service
-server.port=0
+server.port=8080
 eureka.client.service-url.defaultZone=${EUREKA_URL:http://localhost:8761/eureka}
 # if we don't say anything in 2 seconds, there is something wrong with me
 eureka.instance.lease-expiration-duration-in-seconds=2


### PR DESCRIPTION
+ Updated port to 0 which assigns a random port at startup
    * This allows the gateway to use the port it receives from Eureka
+ Updated eureka URL to use an env variable (EUREKA_URL) or fallback to localhost
+ Removed the "/reports" mapping as the gateway will strip this off before
  forwarding to this service.